### PR TITLE
Ignore inadequate icon sources

### DIFF
--- a/lib/manifique/web_client.rb
+++ b/lib/manifique/web_client.rb
@@ -143,7 +143,7 @@ module Manifique
     end
 
     def is_adequate_src(src)
-      !src.nil? && !is_data_url?(src)
+      !src.to_s.empty? && !is_data_url?(src)
     end
 
     def get_icon_type(src)

--- a/lib/manifique/web_client.rb
+++ b/lib/manifique/web_client.rb
@@ -103,7 +103,7 @@ module Manifique
         icon_links.each do |link|
           icon = {}
           icon["src"] = link.attributes["href"].value rescue nil
-          next if icon["src"].to_s.empty?
+          next unless is_adequate_src(icon["src"])
           icon["sizes"] = link.attributes["sizes"].value rescue nil
           icon["type"]  = link.attributes["type"].value rescue get_icon_type(icon["src"])
           @metadata.icons.push icon
@@ -117,7 +117,7 @@ module Manifique
         icon_links.each do |link|
           icon = { "purpose" => "apple-touch-icon" }
           icon["src"] = link.attributes["href"].value rescue nil
-          next if icon["src"].to_s.empty?
+          next unless is_adequate_src(icon["src"])
           icon["sizes"] = link.attributes["sizes"].value rescue nil
           icon["type"]  = link.attributes["type"].value rescue get_icon_type(icon["src"])
           @metadata.icons.push icon
@@ -130,12 +130,20 @@ module Manifique
       if mask_icon_link = @html.at_css("link[rel=mask-icon]")
         icon = { "purpose" => "mask-icon" }
         icon["src"] = mask_icon_link.attributes["href"].value rescue nil
-        return if icon["src"].to_s.empty?
+        return unless is_adequate_src(icon["src"])
         icon["type"]  = link.attributes["type"].value rescue get_icon_type(icon["src"])
         icon["color"] = mask_icon_link.attributes["color"].value rescue nil
         @metadata.icons.push icon
         @metadata.from_html.add "icons"
       end
+    end
+
+    def is_data_url?(src)
+      !!src.match(/^data:/)
+    end
+
+    def is_adequate_src(src)
+      !src.nil? && !is_data_url?(src)
     end
 
     def get_icon_type(src)
@@ -161,6 +169,5 @@ module Manifique
     rescue
       false
     end
-
   end
 end

--- a/spec/fixtures/kommit.html
+++ b/spec/fixtures/kommit.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+	<title>Kommit</title>
+	<meta name="description" content="Augment your memory" />
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<link rel="icon" href="data:;base64,iVBORw0KGgo=">
+	<link rel="canonical" href="/" />
+	<link rel="alternate" hreflang="en" href="/en/" />
+	<link rel="apple-touch-icon" href="https://abcdefg.s3.amazonaws.com/public/icon.jpg">
+</head>
+<head>
+
+<body>
+</body>
+</html>

--- a/spec/manifique/web_client_spec.rb
+++ b/spec/manifique/web_client_spec.rb
@@ -211,6 +211,38 @@ RSpec.describe Manifique::WebClient do
         end
       end
     end
+
+    context "with data URL icons" do
+      before do
+        index_html = File.read(File.join(__dir__, "..", "fixtures", "kommit.html"));
+        stub_request(:get, "https://kosmos.social/").
+          to_return(body: index_html, status: 200, headers: {
+            "Content-Type": "text/html; charset=utf-8"
+          })
+      end
+
+      subject { web_client.fetch_metadata }
+
+      it "returns a metadata object" do
+        expect(subject).to be_kind_of(Manifique::Metadata)
+      end
+
+      it "loads properties from parsed HTML" do
+        expect(subject.name).to eq("Kommit")
+        expect(subject.description).to eq("Augment your memory")
+      end
+
+      it "ignores data URL icons" do
+        expect(subject.icons.length).to eq(1)
+      end
+
+      it "loads icons from link[rel=apple-touch-icon] elements" do
+        apple_touch_icons = subject.icons.select{|i| i["purpose"] == "apple-touch-icon"}
+        expect(apple_touch_icons.length).to eq(1)
+        expect(apple_touch_icons.first["type"]).to eq("image/jpg")
+        expect(apple_touch_icons.first["sizes"]).to be_nil
+      end
+    end
   end
 
 end


### PR DESCRIPTION
Icons with data URLs as source are throwing exceptions when trying to parse their type via the file extension. This fix ignores all icons with data URLs to begin with.