### PR TITLE
Improve handling of failed requests

### DIFF
--- a/lib/manifique/errors.rb
+++ b/lib/manifique/errors.rb
@@ -1,0 +1,11 @@
+module Manifique
+  class Error < ::StandardError
+    attr_reader :type, :url
+
+    def initialize(msg="Encountered an error", type="generic", url)
+      @type = type
+      @url = url
+      super(msg)
+    end
+  end
+end

--- a/lib/manifique/web_client.rb
+++ b/lib/manifique/web_client.rb
@@ -1,8 +1,9 @@
 require 'json'
 require 'faraday'
 require 'faraday_middleware'
-require "nokogiri"
+require 'nokogiri'
 require 'manifique/metadata'
+require 'manifique/errors'
 
 module Manifique
   class WebClient
@@ -160,8 +161,10 @@ module Manifique
       if res.status < 400
         res
       else
-        raise "Could not fetch #{url} successfully (#{res.status})"
+        raise Manifique::Error.new "Failed with HTTP status #{res.status}", "http_#{res.status}", url
       end
+    rescue Faraday::ConnectionFailed, Faraday::TimeoutError, Faraday::SSLError => e
+      raise Manifique::Error.new "Failed to connect", "connection_failed", url
     end
 
     def discover_web_manifest_url(html)

--- a/spec/manifique/web_client_spec.rb
+++ b/spec/manifique/web_client_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Manifique::WebClient do
           }
         end
 
-        it "raises an exception on timouts" do
+        it "raises an exception on timeouts" do
           expect {
             client.send(:do_get_request, 'http://example.com/timeout')
           }.to raise_error("Failed to connect")


### PR DESCRIPTION
This adds a custom exception class with an error type that can be more easily used by clients. It also explicitly handles failed connections as such.

closes #9